### PR TITLE
feat: add await-for-deployment and ignored-build-command inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ ignored-build-command:
   description: Command set for the Ignored Build Step in your project settings, the default script is canceling every preview deployments coming from the Vercel GitHub App.
   required: false
   type: string
-  default: curl -sS "https://raw.githubusercontent.com/snaplet/vercel-action/v1/scripts/ignore-build.mjs" | node --input-type=module
+  default: curl -sS "https://raw.githubusercontent.com/snaplet/vercel-action/v2/scripts/ignore-build.mjs" | node --input-type=module
 ```
 
 ### Outputs

--- a/README.md
+++ b/README.md
@@ -105,6 +105,11 @@ jobs:
 ### Inputs
 
 ```yaml
+await-for-deployment:
+  description: Await for the preview deployment to be ready and output the preview deployment URL
+  required: false
+  type: boolean
+  default: false
 delete:
   description: Delete the preview related data on Vercel
   required: false
@@ -114,4 +119,16 @@ env:
   description: Environment variables to create on Vercel, they are scoped to the "preview" environment and the current branch
   required: false
   type: string
+ignored-build-command:
+  description: Command set for the Ignored Build Step in your project settings, the default script is canceling every preview deployments coming from the Vercel GitHub App.
+  required: false
+  type: string
+  default: curl -sS "https://raw.githubusercontent.com/snaplet/vercel-action/v1/scripts/ignore-build.mjs" | node --input-type=module
+```
+
+### Outputs
+
+```yaml
+deployment-url:
+  description: Preview deployment url
 ```

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,11 @@ author: Snaplet
 description: Trigger Vercel preview deployments when you want to integrate with external services smoothly.
 
 inputs:
+  await-for-deployment:
+    description: Await for the deployment to be ready and output the deployment URL
+    required: false
+    type: boolean
+    default: false
   delete:
     description: Delete the preview related data on Vercel
     required: false
@@ -14,18 +19,32 @@ inputs:
     description: Environment variables to create on Vercel, they are scoped to the "preview" environment and the current branch
     required: false
     type: string
+  ignored-build-command:
+    description: Command set for the Ignored Build Step in your project settings, the default script is canceling every preview deployments coming from the Vercel GitHub App.
+    required: false
+    type: string
+    default: curl -sS "https://raw.githubusercontent.com/snaplet/vercel-action/v1/scripts/ignore-build.mjs" | node --input-type=module
+
+outputs:
+  deployment-url:
+    description: Preview deployment url
+    value: ${{ steps.deploy.outputs.deployment-url }}
 
 runs:
   using: composite
   steps:
     - name: Setup
       shell: bash
+      env:
+        IGNORED_BUILD_COMMAND: ${{ inputs.ignored-build-command }}
       run: node --experimental-fetch --no-warnings ${{ github.action_path }}/scripts/setup.mjs
 
     - if: ${{ inputs.delete == 'false' }}
+      id: deploy
       name: Deploy
       shell: bash
       env:
+        AWAIT_FOR_DEPLOYMENT: ${{ inputs.await-for-deployment }}
         VERCEL_PREVIEW_ENV: ${{ inputs.env }}
       run: node --experimental-fetch --no-warnings ${{ github.action_path }}/scripts/deploy.mjs
 

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
     description: Command set for the Ignored Build Step in your project settings, the default script is canceling every preview deployments coming from the Vercel GitHub App.
     required: false
     type: string
-    default: curl -sS "https://raw.githubusercontent.com/snaplet/vercel-action/v2/scripts/ignore-build.mjs" | node --input-type=module
+    default: curl -sS "https://raw.githubusercontent.com/snaplet/vercel-action/main/scripts/ignore-build.mjs" | node --input-type=module
 
 outputs:
   deployment-url:

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
     description: Command set for the Ignored Build Step in your project settings, the default script is canceling every preview deployments coming from the Vercel GitHub App.
     required: false
     type: string
-    default: curl -sS "https://raw.githubusercontent.com/snaplet/vercel-action/v1/scripts/ignore-build.mjs" | node --input-type=module
+    default: curl -sS "https://raw.githubusercontent.com/snaplet/vercel-action/v2/scripts/ignore-build.mjs" | node --input-type=module
 
 outputs:
   deployment-url:

--- a/scripts/deploy.mjs
+++ b/scripts/deploy.mjs
@@ -51,12 +51,12 @@ console.log("Deployment created.");
 
 if (process.env.AWAIT_FOR_DEPLOYMENT === "true") {
   console.log("Waiting for deployment to be ready...");
-  const deployment = await waitForDeploymentToBeReady(job.createdAt);
+  const deployment = await awaitForDeploymentToBeReady(job.createdAt);
   console.log("Deployment ready.");
   console.log(`::set-output name=deployment-url::${deployment.url}`);
 }
 
-async function waitForDeploymentToBeReady(createdAt) {
+async function awaitForDeploymentToBeReady(createdAt) {
   const url = new URL("https://api.vercel.com/v6/deployments");
   url.search = new URLSearchParams({
     projectId: process.env.VERCEL_PROJECT_ID,
@@ -77,6 +77,6 @@ async function waitForDeploymentToBeReady(createdAt) {
       throw new Error("Deployment failed");
     default:
       await new Promise(resolve => setTimeout(resolve, 2000));
-      return waitForDeploymentToBeReady(createdAt);
+      return awaitForDeploymentToBeReady(createdAt);
   }
 }

--- a/scripts/deploy.mjs
+++ b/scripts/deploy.mjs
@@ -46,5 +46,37 @@ if (!deployHookExists) {
 }
 
 console.log("Creating deployment...");
-await fetch(deployHookUrl, { method: "POST" });
+const { job } = await fetch(deployHookUrl, { method: "POST" });
 console.log("Deployment created.");
+
+if (process.env.AWAIT_FOR_DEPLOYMENT === "true") {
+  console.log("Waiting for deployment to be ready...");
+  const deployment = await waitForDeploymentToBeReady(job.createdAt);
+  console.log("Deployment ready.");
+  console.log(`::set-output name=deployment-url::${deployment.url}`);
+}
+
+async function waitForDeploymentToBeReady(createdAt) {
+  const url = new URL("https://api.vercel.com/v6/deployments");
+  url.search = new URLSearchParams({
+    projectId: process.env.VERCEL_PROJECT_ID,
+    "meta-githubCommitRef": process.env.GITHUB_HEAD_REF,
+    since: createdAt,
+    limit: 1,
+    ...(process.env.VERCEL_TEAM_ID && { teamId: process.env.VERCEL_TEAM_ID }),
+  });
+
+  const { deployments: [deployment] } = await fetch(url, {
+    headers: { Authorization: `Bearer ${process.env.VERCEL_ACCESS_TOKEN}` }
+  }).then(res => res.json());
+
+  switch (deployment?.state) {
+    case "READY":
+      return deployment;
+    case "ERROR":
+      throw new Error("Deployment failed");
+    default:
+      await new Promise(resolve => setTimeout(resolve, 2000));
+      return waitForDeploymentToBeReady(createdAt);
+  }
+}

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -30,8 +30,8 @@ if (process.env.VERCEL_TEAM_ID && !project?.env?.find(env => env.key === "VERCEL
   console.log("VERCEL_TEAM_ID environment variable created.");
 }
 
-const commandForIgnoringBuildStep = `curl -sS "https://raw.githubusercontent.com/snaplet/vercel-action/fix-add-vercel-team-id/scripts/ignore-build.mjs" | node --input-type=module`;
-if (project?.commandForIgnoringBuildStep !== commandForIgnoringBuildStep) {
+const commandForIgnoringBuildStep = process.env.IGNORED_BUILD_COMMAND;
+if (commandForIgnoringBuildStep && project?.commandForIgnoringBuildStep !== commandForIgnoringBuildStep) {
   console.log("Setting Ignored Build Step Command...");
   await vercel("/", {
     method: "PATCH",


### PR DESCRIPTION
In this PR I added two new inputs:

- `await-for-deployment` which will wait for the deployment to be ready before exiting the action. It will also output the `deployment-url` to be used in subsequent steps like e2e tests.
- `ignored-build-command` which can now be customized. This command is used to short-circuit Vercel Github App and skip the preview deployments coming from it, so only the ones triggered by the GitHub action with deploy hooks are allowed.