### PR TITLE
Use deployment API instead of deploy hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Vercel preview deployments happen automatically with each commit. This action allows you to take control over automatic deployments, which is helpful when you want to create external resources (like a database) and wait for services to be ready before deploying your code on Vercel.
 
-To take control over the automatic deployments, this action is injecting a custom [script](scripts/ignore-build.mjs) into the [Ignored Build Step](https://vercel.com/guides/how-do-i-use-the-ignored-build-step-field-on-vercel) in your Vercel project settings. This script is canceling all preview deployments coming from the Vercel Github App and only allows preview deployments coming from this GitHub action (based on [deploy hooks](https://vercel.com/docs/concepts/git/deploy-hooks)).
+To take control over the automatic deployments, this action is injecting a custom [script](scripts/ignore-build.mjs) into the [Ignored Build Step](https://vercel.com/guides/how-do-i-use-the-ignored-build-step-field-on-vercel) in your Vercel project settings. This script is canceling all preview deployments coming from the Vercel GitHub App and only allows deployments created by this GitHub action (based on [Vercel REST API](https://vercel.com/docs/rest-api#endpoints/deployments/create-a-new-deployment)).
 
 Combine this action with [snaplet/action](https://github.com/marketplace/actions/snaplet-preview-databases) to get preview databases with production-accurate data for each of your Vercel preview deployment. [Learn more here.](#with-snaplet)
 

--- a/scripts/delete.mjs
+++ b/scripts/delete.mjs
@@ -2,13 +2,6 @@ import { vercel } from "./vercel.mjs";
 
 const project = await vercel("/");
 
-const deployHookId = project.link.deployHooks.find(deployHook => deployHook.ref === process.env.GITHUB_HEAD_REF)?.id;
-if (deployHookId) {
-  console.log("Deleting deploy hook...");
-  await vercel(`/deploy-hooks/${deployHookId}`, { method: "DELETE" });
-  console.log("Deploy hook deleted.");
-}
-
 await Promise.all(
   project.env
     .filter((env) => env.target[0] === "preview" && env.gitBranch === process.env.GITHUB_HEAD_REF)

--- a/scripts/deploy.mjs
+++ b/scripts/deploy.mjs
@@ -100,7 +100,6 @@ async function createNewDeploymentForBranch(branchName) {
         type: "github",
         sha: process.env.GITHUB_SHA,
       },
-      target: "staging",
     }),
   }).then(async res => {
     if (!res.ok) {

--- a/scripts/deploy.mjs
+++ b/scripts/deploy.mjs
@@ -90,13 +90,13 @@ async function createNewDeploymentForBranch(branchName) {
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      name: `snaplet-${process.env.GITHUB_HEAD_REF}`,
+      name: `snaplet-${process.env.GITHUB_SHA}`,
       project: process.env.VERCEL_PROJECT_ID,
       gitSource: {
         ref: branchName,
         repoId: process.env.GITHUB_REPOSITORY_ID,
         type: "github",
-        sha: process.env.GITHUB_HEAD_REF,
+        sha: process.env.GITHUB_SHA,
       },
       target: "staging",
     }),

--- a/scripts/deploy.mjs
+++ b/scripts/deploy.mjs
@@ -80,6 +80,7 @@ async function createNewDeploymentForBranch(branchName) {
   const url = new URL("https://api.vercel.com/v13/deployments");
   url.search = new URLSearchParams({
     ...(process.env.VERCEL_TEAM_ID && { teamId: process.env.VERCEL_TEAM_ID }),
+    forceNew: 1,
   });
 
   return fetch(url, {

--- a/scripts/deploy.mjs
+++ b/scripts/deploy.mjs
@@ -89,6 +89,7 @@ async function createNewDeploymentForBranch(branchName) {
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
+      name: `snaplet-${process.env.GITHUB_HEAD_REF}`,
       project: process.env.VERCEL_PROJECT_ID,
       gitSource: {
         ref: branchName,

--- a/scripts/deploy.mjs
+++ b/scripts/deploy.mjs
@@ -1,6 +1,6 @@
 console.log("Updating environment variables...");
 await updateEnvironmentVariables();
-console.log("Deployment updated.");
+console.log("Environment variables updated.");
 
 console.log("Creating deployment...");
 let deployment = await createNewDeploymentForBranch(

--- a/scripts/deploy.mjs
+++ b/scripts/deploy.mjs
@@ -1,16 +1,87 @@
-console.log("Creating deployment...")
-let deployment = await createNewDeploymentForBranch(process.env.GITHUB_HEAD_REF)
-console.log("Deployment created.")
+console.log("Updating environment variables...");
+await updateEnvironmentVariables();
+console.log("Deployment updated.");
+
+console.log("Creating deployment...");
+let deployment = await createNewDeploymentForBranch(
+  process.env.GITHUB_HEAD_REF
+);
+console.log("Deployment created.");
 
 if (process.env.AWAIT_FOR_DEPLOYMENT === "true") {
-  console.log("Waiting for deployment to be ready...")
-  deployment = await awaitForDeploymentToBeReady(deployment)
-  console.log("Deployment ready.")
-  console.log(`::set-output name=deployment-url::${deployment.url}`)
+  console.log("Waiting for deployment to be ready...");
+  deployment = await awaitForDeploymentToBeReady(deployment);
+  console.log("Deployment ready.");
+  console.log(`::set-output name=deployment-url::${deployment.url}`);
+}
+
+async function updateEnvironmentVariables() {
+  const environmentVariables = process.env.VERCEL_PREVIEW_ENV.trim()
+    .split("\n")
+    .filter(line => line.trim().length > 0 && !line.trim().startsWith("#"))
+    .map(line => {
+      const [key, ...parts] = line.trim().split("=");
+      const value = parts.join("=");
+      return { key, value };
+    });
+
+  if (environmentVariables.length === 0) {
+    return;
+  }
+
+  const url = new URL(
+    `https://api.vercel.com/v10/projects/${process.env.VERCEL_PROJECT_ID}/env`
+  );
+  url.search = new URLSearchParams({
+    ...(process.env.VERCEL_TEAM_ID && { teamId: process.env.VERCEL_TEAM_ID }),
+    upsert: true,
+  });
+
+  return fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${process.env.VERCEL_ACCESS_TOKEN}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(
+      environmentVariables.map(({ key, value }) => ({
+        gitBranch: process.env.GITHUB_HEAD_REF,
+        key,
+        target: ["preview"],
+        type: "encrypted",
+        value,
+      }))
+    ),
+  })
+    .then(async res => {
+      if (!res.ok) {
+        const errResponse = await res.json();
+        throw new Error(
+          errResponse?.error?.message ??
+            "Could not create environment variables"
+        );
+      }
+      return res.json();
+    })
+    .then(res => {
+      // Since we are doing a batch upsert of environment variables it could
+      // still be the case that the creation of one in the batch failed.
+      if (res.failed?.length > 0) {
+        throw new Error(
+          res.failed[0].message ?? "Updating environment variables failed."
+        );
+      }
+
+      return res;
+    });
 }
 
 async function createNewDeploymentForBranch(branchName) {
-  const url = new URL("https://api.vercel.com/v13/deployments")
+  const url = new URL("https://api.vercel.com/v13/deployments");
+  url.search = new URLSearchParams({
+    ...(process.env.VERCEL_TEAM_ID && { teamId: process.env.VERCEL_TEAM_ID }),
+  });
+
   return fetch(url, {
     method: "POST",
     headers: {
@@ -29,35 +100,45 @@ async function createNewDeploymentForBranch(branchName) {
     }),
   }).then(async res => {
     if (!res.ok) {
-      const errResponse = await res.json()
+      const errResponse = await res.json();
       throw new Error(
         errResponse?.error?.message ?? "Could not create deployment"
-      )
+      );
     }
-    return res.json()
-  })
+    return res.json();
+  });
 }
 
 async function awaitForDeploymentToBeReady(deployment) {
-  const url = new URL(`https://api.vercel.com/v13/deployments/${deployment.id}`)
+  const url = new URL(
+    `https://api.vercel.com/v13/deployments/${deployment.id}`
+  );
+  url.search = new URLSearchParams({
+    ...(process.env.VERCEL_TEAM_ID && { teamId: process.env.VERCEL_TEAM_ID }),
+  });
+
   const freshDeployment = await fetch(url, {
     headers: { Authorization: `Bearer ${process.env.VERCEL_ACCESS_TOKEN}` },
   }).then(async res => {
     if (!res.ok) {
-      const errResponse = await res.json()
-      throw new Error(errResponse?.error?.message ?? "Could not get deployment")
+      const errResponse = await res.json();
+      throw new Error(
+        errResponse?.error?.message ?? "Could not get deployment"
+      );
     }
 
-    return res.json()
-  })
+    return res.json();
+  });
 
   switch (freshDeployment?.readyState) {
     case "READY":
-      return freshDeployment
+      return freshDeployment;
+    case "CANCELED":
+      throw new Error("Deployment cancelled");
     case "ERROR":
-      throw new Error("Deployment failed")
+      throw new Error("Deployment failed");
     default:
-      await new Promise(resolve => setTimeout(resolve, 2000))
-      return awaitForDeploymentToBeReady(freshDeployment)
+      await new Promise(resolve => setTimeout(resolve, 2000));
+      return awaitForDeploymentToBeReady(freshDeployment);
   }
 }

--- a/scripts/deploy.mjs
+++ b/scripts/deploy.mjs
@@ -1,82 +1,63 @@
-import { vercel } from "./vercel.mjs";
-
-const project = await vercel("/");
-
-let deployHookUrl = project?.link?.deployHooks?.find(deployHook => deployHook.ref === process.env.GITHUB_HEAD_REF)?.url;
-
-const deployHookExists = Boolean(deployHookUrl)
-
-if (!deployHookExists) {
-  console.log("Creating deploy hook...");
-  const updatedProject = await vercel("/deploy-hooks", {
-    method: "POST",
-    body: JSON.stringify({
-      name: process.env.GITHUB_HEAD_REF,
-      ref: process.env.GITHUB_HEAD_REF,
-    }),
-  });
-  deployHookUrl = updatedProject?.link?.deployHooks?.find(deployHook => deployHook.ref === process.env.GITHUB_HEAD_REF)?.url;
-  console.log("Deploy hook created.");
-
-  const environmentVariables = process.env.VERCEL_PREVIEW_ENV
-    .trim()
-    .split("\n")
-    .filter(line => line.trim().length > 0 && !line.trim().startsWith("#"))
-    .map(line => {
-      const [key, ...parts] = line.trim().split("=");
-      const value = parts.join("=");
-      return { key, value };
-    });
-  await Promise.all(environmentVariables
-    .map(async ({ key, value }) => {
-      console.log(`Creating ${key} environment variable...`);
-      await vercel("/env", {
-        method: "POST",
-        body: JSON.stringify({
-          gitBranch: process.env.GITHUB_HEAD_REF,
-          key,
-          target: ["preview"],
-          type: "encrypted",
-          value,
-        }),
-      });
-      console.log(`${key} environment variable created.`);
-    })
-  );
-}
-
-console.log("Creating deployment...");
-const { job } = await fetch(deployHookUrl, { method: "POST" }).then(res => res.json());
-console.log("Deployment created.");
+console.log("Creating deployment...")
+let deployment = await createNewDeploymentForBranch(process.env.GITHUB_HEAD_REF)
+console.log("Deployment created.")
 
 if (process.env.AWAIT_FOR_DEPLOYMENT === "true") {
-  console.log("Waiting for deployment to be ready...");
-  const deployment = await awaitForDeploymentToBeReady(job.createdAt);
-  console.log("Deployment ready.");
-  console.log(`::set-output name=deployment-url::${deployment.url}`);
+  console.log("Waiting for deployment to be ready...")
+  deployment = await awaitForDeploymentToBeReady(deployment)
+  console.log("Deployment ready.")
+  console.log(`::set-output name=deployment-url::${deployment.url}`)
 }
 
-async function awaitForDeploymentToBeReady(createdAt) {
-  const url = new URL("https://api.vercel.com/v6/deployments");
-  url.search = new URLSearchParams({
-    projectId: process.env.VERCEL_PROJECT_ID,
-    "meta-githubCommitRef": process.env.GITHUB_HEAD_REF,
-    since: createdAt,
-    limit: 1,
-    ...(process.env.VERCEL_TEAM_ID && { teamId: process.env.VERCEL_TEAM_ID }),
-  });
+async function createNewDeploymentForBranch(branchName) {
+  const url = new URL("https://api.vercel.com/v13/deployments")
+  return fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${process.env.VERCEL_ACCESS_TOKEN}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      project: process.env.VERCEL_PROJECT_ID,
+      gitSource: {
+        ref: branchName,
+        repoId: process.env.GITHUB_REPOSITORY_ID,
+        type: "github",
+        sha: process.env.GITHUB_HEAD_REF,
+      },
+      target: "staging",
+    }),
+  }).then(async res => {
+    if (!res.ok) {
+      const errResponse = await res.json()
+      throw new Error(
+        errResponse?.error?.message ?? "Could not create deployment"
+      )
+    }
+    return res.json()
+  })
+}
 
-  const { deployments: [deployment] } = await fetch(url, {
-    headers: { Authorization: `Bearer ${process.env.VERCEL_ACCESS_TOKEN}` }
-  }).then(res => res.json());
+async function awaitForDeploymentToBeReady(deployment) {
+  const url = new URL(`https://api.vercel.com/v13/deployments/${deployment.id}`)
+  const freshDeployment = await fetch(url, {
+    headers: { Authorization: `Bearer ${process.env.VERCEL_ACCESS_TOKEN}` },
+  }).then(async res => {
+    if (!res.ok) {
+      const errResponse = await res.json()
+      throw new Error(errResponse?.error?.message ?? "Could not get deployment")
+    }
 
-  switch (deployment?.state) {
+    return res.json()
+  })
+
+  switch (freshDeployment?.readyState) {
     case "READY":
-      return deployment;
+      return freshDeployment
     case "ERROR":
-      throw new Error("Deployment failed");
+      throw new Error("Deployment failed")
     default:
-      await new Promise(resolve => setTimeout(resolve, 2000));
-      return awaitForDeploymentToBeReady(createdAt);
+      await new Promise(resolve => setTimeout(resolve, 2000))
+      return awaitForDeploymentToBeReady(freshDeployment)
   }
 }

--- a/scripts/deploy.mjs
+++ b/scripts/deploy.mjs
@@ -90,7 +90,9 @@ async function createNewDeploymentForBranch(branchName) {
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      name: `snaplet-${process.env.GITHUB_SHA}`,
+      // Name prefix is important here as it is used in the build ignore step
+      // to determine if it was created by this action.
+      name: `snaplet-action-${process.env.GITHUB_SHA.substring(0, 7)}`,
       project: process.env.VERCEL_PROJECT_ID,
       gitSource: {
         ref: branchName,

--- a/scripts/ignore-build.mjs
+++ b/scripts/ignore-build.mjs
@@ -18,7 +18,7 @@ if (process.env.VERCEL_ENV === "preview") {
   const deployment = await fetch(`https://api.vercel.com/v13/deployments/${process.env.VERCEL_URL}${teamId}`, {
     headers: { Authorization: `Bearer ${process.env.VERCEL_ACCESS_TOKEN}` }
   }).then(res => res.json());
-  if (!deployment.meta.deployHookId) {
+  if (!deployment.name.startsWith('snaplet-action-')) {
     process.exit(0);
   }
 }


### PR DESCRIPTION
Greetings from Vercel! Thank you for setting up this Action to integrate your product with our platform!

We noticed a limitation with the current approach using our Deploy Hooks feature:
There is a limit of 5 Deploy Hooks per project that can be created at a time, which means you are limited to 5 preview branches when using your Action.

We think using our REST API instead for this could improve it and remove the limitation and that is why I want to submit this PR:
- We added a new way to upsert environment variables (replacing them if they already exist) for this action
- We replaced the deploy hook thing with a direct call to our [Create Deployment API](https://vercel.com/docs/rest-api#endpoints/deployments/create-a-new-deployment)
- The detection for the Build Ignore Script now relies on the deployment name (starts with `snaplet-action-` instead of checking if it was created from a Deploy Hook)

We tested it internally and it worked well, so would love if you could take 👀 on this 👍 