### PR TITLE
Fix wrong commit sha

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,9 @@ runs:
       env:
         AWAIT_FOR_DEPLOYMENT: ${{ inputs.await-for-deployment }}
         VERCEL_PREVIEW_ENV: ${{ inputs.env }}
+        # We cannot rely on `GITHUB_SHA` env for pull requests
+        # See: https://github.com/orgs/community/discussions/26325
+        VERCEL_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       run: node --experimental-fetch --no-warnings ${{ github.action_path }}/scripts/deploy.mjs
 
     - if: ${{ inputs.delete == 'true' }}

--- a/scripts/deploy.mjs
+++ b/scripts/deploy.mjs
@@ -96,13 +96,13 @@ async function createNewDeploymentForBranch(branchName) {
     body: JSON.stringify({
       // Name prefix is important here as it is used in the build ignore step
       // to determine if it was created by this action.
-      name: `snaplet-action-${process.env.GITHUB_SHA.substring(0, 7)}`,
+      name: `snaplet-action-${process.env.VERCEL_COMMIT_SHA.substring(0, 7)}`,
       project: process.env.VERCEL_PROJECT_ID,
       gitSource: {
         ref: branchName,
         repoId: process.env.GITHUB_REPOSITORY_ID,
         type: "github",
-        sha: process.env.GITHUB_SHA,
+        sha: process.env.VERCEL_COMMIT_SHA,
       },
     }),
   }).then(async res => {


### PR DESCRIPTION
TIL that `GITHUB_SHA` is a ghost commit with the same content but with a different sha when it is triggered from a PR workflow 🙈 
https://github.com/orgs/community/discussions/26325

So because the workflow is triggered from a Pull request we pull the commit with the wrong sha and add the status to the wrong commit after the Vercel build is done.
That's why the status check never gets updated from `Canceled by Ignored Build Step`.

Fix here is not to rely on `GITHUB_SHA` but instead get it directly from the context if available.

Related discussion: https://github.com/vercel/vercel/discussions/8328#discussioncomment-5258846

