### PR TITLE
[Feature] Exclude Specific Branches from Preview Deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ env:
   description: Environment variables to create on Vercel, they are scoped to the "preview" environment and the current branch
   required: false
   type: string
+ignored-branches:
+  description: Branches to ignore the preview deployments. The default value is "main,master,develop".
+  required: false
+  default: main,master,develop
 ignored-build-command:
   description: Command set for the Ignored Build Step in your project settings, the default script is canceling all preview deployments coming from the Vercel Github App and only allows preview deployments coming from this GitHub action.
   required: false

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,11 @@ inputs:
     description: Environment variables to create on Vercel, they are scoped to the "preview" environment and the current branch
     required: false
     type: string
+  ignored-branches:
+    description: Branches to ignore from preview deployments, the default value is "main", "master" and "develop"
+    required: false
+    type: string
+    default: main,master,develop
   ignored-build-command:
     description: Command set for the Ignored Build Step in your project settings, the default script is canceling every preview deployments coming from the Vercel GitHub App.
     required: false
@@ -36,6 +41,7 @@ runs:
     - name: Setup
       shell: bash
       env:
+        IGNORED_BRANCHES: ${{ inputs.ignored-branches }}
         IGNORED_BUILD_COMMAND: ${{ inputs.ignored-build-command }}
       run: node --experimental-fetch --no-warnings ${{ github.action_path }}/scripts/setup.mjs
 

--- a/scripts/ignore-build.mjs
+++ b/scripts/ignore-build.mjs
@@ -1,5 +1,11 @@
 import https from "node:https";
 
+// get ignored branches
+let ignoredBranches = [];
+if (process.argv[2] && process.argv[2] === '-b') {
+  ignoredBranches = process.argv[3].split(',');
+}
+
 // dumb fetch implementation
 const fetch = (url, options = {}) => new Promise((resolve, reject) => {
   const req = https.request(url, options, (res) => {
@@ -13,7 +19,7 @@ const fetch = (url, options = {}) => new Promise((resolve, reject) => {
   req.end();
 });
 
-if (process.env.VERCEL_ENV === "preview") {
+if (process.env.VERCEL_ENV === "preview" && !ignoredBranches.includes(process.env.VERCEL_GIT_COMMIT_REF)) {
   const teamId = process.env.VERCEL_TEAM_ID ? `?teamId=${process.env.VERCEL_TEAM_ID}` : '';
   const deployment = await fetch(`https://api.vercel.com/v13/deployments/${process.env.VERCEL_URL}${teamId}`, {
     headers: { Authorization: `Bearer ${process.env.VERCEL_ACCESS_TOKEN}` }

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -30,7 +30,8 @@ if (process.env.VERCEL_TEAM_ID && !project?.env?.find(env => env.key === "VERCEL
   console.log("VERCEL_TEAM_ID environment variable created.");
 }
 
-const commandForIgnoringBuildStep = process.env.IGNORED_BUILD_COMMAND;
+const ignoredBranches = process.env.IGNORED_BRANCHES || "";
+const commandForIgnoringBuildStep = `${process.env.IGNORED_BUILD_COMMAND} - -b ${ignoredBranches.join(",")}`;
 if (commandForIgnoringBuildStep && project?.commandForIgnoringBuildStep !== commandForIgnoringBuildStep) {
   console.log("Setting Ignored Build Step Command...");
   await vercel("/", {


### PR DESCRIPTION
This pull request introduces a new feature to the `snaplet/vercel-action` GitHub Action, allowing users to specify branches that should be excluded from Vercel preview deployments. This enhancement is particularly useful in development workflows like GitFlow, where certain branches (e.g., `main`, `develop`) are considered as production (or staging) and should not have associated preview deployments.

### Features

- **Ignore Branches**: Users can now define a list of branches that the Vercel GitHub Action should ignore when triggering preview deployments. This is controlled by the new `ignored-branches` input.
  
- **Custom Ignore Build Command**: Provides the capability to set a custom command for the Ignored Build Step in project settings, ensuring flexibility in handling ignored branches.

### Implementation Details

1. **GitHub Action Input**:

   Added new inputs to the GitHub Action:
   - `ignored-branches`: Specifies the branches to be excluded from preview deployments. Defaults to "main,master,develop".

2. **Setup Script Changes**:

   Modified the `scripts/setup.mjs` to accept the `-b` argument, enabling easy specification of branches to be ignored. The script dynamically constructs the command for the Ignored Build Step based on the `IGNORED_BRANCHES` and `IGNORED_BUILD_COMMAND` environment variables.

### Motivation

In workflows like GitFlow, the `develop` and `main` branches are often considered as production. However, Vercel currently supports only one production deployment at a time. This feature allows teams to bypass preview deployments for specific branches, aligning better with their development practices without cluttering the deployment environment.

### Usage

Users can specify the branches to ignore in the GitHub Action configuration like so:

```yaml
ignored-branches:
  description: Branches to ignore for preview deployments. Defaults to "main,master,develop".
  required: false
  default: main,master,develop
```

By setting the `ignored-branches` input, teams can customize which branches should bypass the preview deployment process, adding flexibility to their continuous deployment workflows.